### PR TITLE
build: update publish scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@clr/city",
+  "name": "@cds/city",
   "version": "1.1.0",
   "description": "Clarity City Typeface",
   "main": "css/index.css",


### PR DESCRIPTION
Changing scope seems like a breaking change to me. Happy to revert if it is not. 

### NOTE
The can be merged but not published. The [clarity](https://github.com/vmware/clarity) PR for updating scope will depend on the published artifacts being available. 

Signed-off-by: Matt Hippely <mhippely@vmware.com>